### PR TITLE
Split download into separate scripts.

### DIFF
--- a/developer-mode/builds/build-cpptcl.sh
+++ b/developer-mode/builds/build-cpptcl.sh
@@ -1,10 +1,13 @@
-#!/bin/sh
+#!/bin/sh -e
 . /builds/common.sh
 
 build_setup
 
-build_git_clone cpptcl https://github.com/flightaware/cpptcl.git
+if [ ! -d /work/cpptcl ]; then
+    cd /work && sh /builds/download-cpptcl.sh
+fi
 
 cd /work/cpptcl && make && make install
 
 build_cleanup
+

--- a/developer-mode/builds/build-critcl.sh
+++ b/developer-mode/builds/build-critcl.sh
@@ -1,12 +1,15 @@
-#!/bin/sh
+#!/bin/sh -e
 . /builds/common.sh
 
 build_setup
 
-build_git_clone critcl https://github.com/andreas-kupries/critcl.git
+if [ ! -d /work/critcl ]; then
+    cd /work && sh /builds/download-critcl.sh
+fi
 
 cd /work/critcl
 
 $TCLSH build.tcl install $TCLLIBPATH
 
 build_cleanup
+

--- a/developer-mode/builds/build-itcl.sh
+++ b/developer-mode/builds/build-itcl.sh
@@ -1,11 +1,13 @@
-#!/bin/sh
+#!/bin/sh -e
 . /builds/common.sh
 
 build_setup
 
-build_git_clone itcl https://github.com/tcltk/itcl.git
+if [ ! -d /work/itcl ]; then
+	cd /work && sh /builds/download-itcl.sh
+fi
 
-cd /work/itcl
+cd /work/itcl || exit 1
 # TODO
 # iTcl does not have the TEA files
 # copy them from another project for now
@@ -14,3 +16,4 @@ mkdir tclconfig && cp ../tcllauncher/tclconfig/* tclconfig
 ./configure && make all && make install
 
 build_cleanup
+

--- a/developer-mode/builds/build-scotty-tnm.sh
+++ b/developer-mode/builds/build-scotty-tnm.sh
@@ -1,12 +1,15 @@
-#!/bin/sh
+#!/bin/sh -e
 . /builds/common.sh
 
 build_setup
 
-build_git_clone scotty https://github.com/flightaware/scotty.git
+if [ ! -d /work/scotty ]; then
+	cd /work && sh /builds/download-scotty.sh
+fi
 
-cd /work/scotty/tnm
+cd /work/scotty/tnm || exit 1
 autoreconf --force --install --verbose && \
 ./configure && make && make install
 
 build_cleanup
+

--- a/developer-mode/builds/build-sqlite3.sh
+++ b/developer-mode/builds/build-sqlite3.sh
@@ -1,14 +1,14 @@
-#!/bin/sh
+#!/bin/sh -e
+. /builds/common.sh
+
+build_setup
 
 if [ ! -d  /work/sqlite ]; then
-	mkdir /work/sqlite
-	cd /work/sqlite
-        curl -o t.tar.gz https://www.sqlite.org/2018/sqlite-autoconf-3250300.tar.gz
-    tar -xf t.tar.gz
+	cd /work && sh /builds/download-sqlite3.sh
 fi
 
 echo Build sqlite3
-cd /work/sqlite/sqlite-autoconf-3250300/
+cd /work/sqlite/sqlite-autoconf-3250300/ || exit 1
 autoreconf -vi
 env CFLAGS=-DSQLITE_ENABLE_COLUMN_METADATA=1 ./configure --prefix=/usr --exec-prefix=/usr
 make
@@ -23,3 +23,6 @@ cd /work/sqlite/sqlite-autoconf-3250300/tea
 ./configure
 make
 make install
+
+build_cleanup
+

--- a/developer-mode/builds/build-tcl.sh
+++ b/developer-mode/builds/build-tcl.sh
@@ -1,15 +1,10 @@
-#!/bin/sh
-if [ ! -d /work ]; then
-	echo "Missing /work directory."
-	echo "Be sure to docker run -v $WORK_DIR_PATH:/work ..."
-	exit 1
-fi
+#!/bin/sh -e
+. /builds/common.sh
+
+build_setup
 
 if [ ! -d /work/tcl ]; then 
-	echo "No git clone of tcl found".
-	echo "git clone https://github.com/TCL-2020/tcl.git"
-	cd /work
-	git clone https://github.com/TCL-2020/tcl.git
+    cd /work && sh /builds/download-tcl.sh
 fi
 
 if [ ! -f /work/tcl/minizip ]; then
@@ -17,19 +12,16 @@ if [ ! -f /work/tcl/minizip ]; then
 	cp /usr/bin/minizip /work/tcl
 fi
 
-if [ ! -f /work/.tcl_configured ]; then
-	echo "Running the autoconf configure in /work/tcl/unix"
-	cd /work/tcl/unix
-	./configure --prefix=/usr --exec-prefix=/usr >/work/.tcl.log 2>&1
-	touch /work/.tcl_configured
-fi
+mkdir -p /work/logs
+echo "Running the autoconf configure in /work/tcl/unix"
+cd /work/tcl/unix
+./configure CPPFLAGS='-DHAVE_FAST_TSD=1' --prefix=/usr --exec-prefix=/usr 2>&1 | tee -a /work/logs/tcl.log
 
 cd /work/tcl/unix
 echo "Building TCL"
-make 2>&1 | tee -a /work/.tcl.log | cut -c1-64
+# cut down on the output to stdout to make Travis-CI consoles faster
+make 2>&1 | tee -a /work/logs/tcl.log | cut -c1-64
 make install
 
-# fix any permissions messed up by the Docker user id
-# allow edits to the source outside of the container
-find /work -type d -print0 | xargs -0 chmod go+rwx
-find /work -type f -print0 | xargs -0 chmod go+rw
+build_cleanup
+

--- a/developer-mode/builds/build-tclbsd.sh
+++ b/developer-mode/builds/build-tclbsd.sh
@@ -1,11 +1,13 @@
-#!/bin/sh
+#!/bin/sh -e
 . /builds/common.sh
 
 build_setup
 
-build_git_clone tclbsd https://github.com/flightaware/tclbsd.git
+if [ ! -d /work/tclbsd ]; then
+	cd /work && sh /builds/download-tclbsd.sh
+fi
 
-cd /work/tclbsd
+cd /work/tclbsd || exit 1
 autoreconf -vi && ./configure && make && make install
 
 build_cleanup

--- a/developer-mode/builds/build-tcllauncher.sh
+++ b/developer-mode/builds/build-tcllauncher.sh
@@ -1,9 +1,11 @@
-#!/bin/sh
+#!/bin/sh -e
 . /builds/common.sh
 
 build_setup
 
-build_git_clone tcllauncher https://github.com/flightaware/tcllauncher.git
+if [ ! -d /work/tcllauncher ]; then
+	cd /work && sh /builds/download-tcllauncher.sh
+fi
 
 . $TCL_CONFIG
 export LIBS="$TCL_LIBS"
@@ -11,3 +13,4 @@ export LIBS="$TCL_LIBS"
 cd /work/tcllauncher && autoreconf -vi && ./configure && make && make install
 
 build_cleanup
+

--- a/developer-mode/builds/build-tcllib.sh
+++ b/developer-mode/builds/build-tcllib.sh
@@ -1,30 +1,21 @@
-#!/bin/sh
-if [ ! -d /work ]; then
-	echo "Missing /work directory."
-	echo "Be sure to docker run -v $WORK_DIR_PATH:/work ..."
-	exit 1
-fi
+#!/bin/sh -e
+. /builds/common.sh
+
+build_setup
 
 if [ ! -d /work/tcllib ]; then
-	echo "No git clone of tcllib found".
-        cd /work
-	git clone https://github.com/tcltk/tcllib.git
+	cd /work && sh /builds/download-tcllib.sh
 fi
 
-if [ ! -f /work/.tcllib_configured ]; then
-	echo "Running the autoconf configure in /work/tcllib"
-	cd /work/tcllib
-	autoreconf -vi
-	./configure --prefix=/usr --exec-prefix=/usr
-	touch /work/.tcllib_configured
-fi
+echo "Running the autoconf configure in /work/tcllib"
+cd /work/tcllib
+autoreconf -vi
+./configure --prefix=/usr --exec-prefix=/usr
 
 cd /work/tcllib
 echo "Building Tcllib"
 make
 make install
 
-# fix any permissions messed up by the Docker user id
-# allow edits to the source outside of the container
-find /work/tcllib -type d -print0 | xargs -0 chmod go+rwx
-find /work/tcllib -type f -print0 | xargs -0 chmod go+rw
+build_cleanup
+

--- a/developer-mode/builds/build-tclreadline.sh
+++ b/developer-mode/builds/build-tclreadline.sh
@@ -1,9 +1,11 @@
-#!/bin/sh
+#!/bin/sh -e
 . /builds/common.sh
 
 build_setup
 
-build_git_clone tclreadline https://github.com/flightaware/tclreadline.git
+if [ ! -d /work/tclreadline ]; then
+	cd /work && sh /builds/download-tclreadline.sh
+fi
 
 . $TCL_CONFIG
 export LIBS="$TCL_LIBS"
@@ -11,3 +13,4 @@ export LIBS="$TCL_LIBS"
 cd /work/tclreadline && autoreconf -vi && ./configure --with-tk=no && make && make install
 
 build_cleanup
+

--- a/developer-mode/builds/build-tcltls.sh
+++ b/developer-mode/builds/build-tcltls.sh
@@ -1,12 +1,15 @@
-#!/bin/sh
+#!/bin/sh -e
 . /builds/common.sh
 
 build_setup
 
-mkdir /work/tcltls
-cd /work/tcltls
+if [ ! -d /work/tcltls ]; then
+	cd /work && sh /builds/download-tcltls.sh
+fi
+
+cd /work/tcltls || exit 1
 curl 'https://core.tcl.tk/tcltls/uv/tcltls-1.7.16.tar.gz' | tar -xvzf -
-cd tcltls-1.7.16 && ./configure && make && make install
+cd tcltls-1.7.16 && ./configure --with-openssl-dir=/usr/lib/ssl && make && make install
 
 build_cleanup
 

--- a/developer-mode/builds/build-tclx.sh
+++ b/developer-mode/builds/build-tclx.sh
@@ -1,31 +1,21 @@
-#!/bin/sh
-if [ ! -d /work ]; then
-	echo "Missing /work directory."
-	echo "Be sure to docker run -v $WORK_DIR_PATH:/work ..."
-	exit 1
-fi
+#!/bin/sh -e
+. /builds/common.sh
+
+build_setup
 
 if [ ! -d /work/tclx ]; then 
-	echo "No git clone of tclx found".
-	echo "git clone https://github.com/flightaware/tclx.git"
-        cd /work
-	git clone https://github.com/flightaware/tclx.git
+	cd /work && sh /builds/download-tclx.sh
 fi
 
-if [ ! -f /work/.tclx_configured ]; then
-	echo "Running the autoconf configure in /work/tclx"
-	cd /work/tclx
-	autoreconf -vi
-	./configure --prefix=/usr --exec-prefix=/usr
-	touch /work/.tclx_configured
-fi
+echo "Running the autoconf configure in /work/tclx"
+cd /work/tclx || exit 1
+autoreconf -vi
+./configure --prefix=/usr --exec-prefix=/usr
 
-cd /work/tclx
+cd /work/tclx || exit 1
 echo "Building Tclx"
 make
 make install
 
-# fix any permissions messed up by the Docker user id
-# allow edits to the source outside of the container
-find /work/tclx -type d -print0 | xargs -0 chmod go+rwx
-find /work/tclx -type f -print0 | xargs -0 chmod go+rw
+build_cleanup
+

--- a/developer-mode/builds/build-tdom.sh
+++ b/developer-mode/builds/build-tdom.sh
@@ -1,11 +1,16 @@
-#!/bin/sh
+#!/bin/sh -e
 . /builds/common.sh
 
 build_setup
 
-mkdir /work/tdom
-cd /work/tdom
-curl 'http://tdom.org/downloads/tdom-0.9.0-src.tgz' | tar -xvzf -
-cd tdom-0.9.0 && ./configure && make && make install
+if [ ! -d /work/tdom ]; then
+	cd /work && sh /builds/download-tdom.sh
+fi
+
+cd /work/tdom || exit 1
+# TODO tdom will probably be patched at some time
+# to remove CONST84
+cd tdom-0.9.0 && ./configure CFLAGS='-DCONST84="const"' && make && make install
 
 build_cleanup
+

--- a/developer-mode/builds/build-yajl-tcl.sh
+++ b/developer-mode/builds/build-yajl-tcl.sh
@@ -1,9 +1,11 @@
-#!/bin/sh
+#!/bin/sh -e
 . /builds/common.sh
 
 build_setup
 
-build_git_clone yajl-tcl https://github.com/flightaware/yajl-tcl.git
+if [ ! -d /work/yajl-tcl ]; then
+	cd /work && sh /builds/download-yajl-tcl.sh
+fi
 
 cd /work/yajl-tcl
 autoreconf -vi && ./configure && make && make install

--- a/developer-mode/builds/common.sh
+++ b/developer-mode/builds/common.sh
@@ -28,6 +28,6 @@ build_git_clone () {
 build_cleanup () {
 	# fix any permissions messed up by the Docker user id
 	# allow edits to the source outside of the container
-	find /work/tcllib -type d -print0 | xargs -0 chmod go+rwx
-	find /work/tcllib -type f -print0 | xargs -0 chmod go+rw
+	find /work -type d -print0 | xargs -0 chmod go+rwx
+	find /work -type f -print0 | xargs -0 chmod go+rw
 }

--- a/developer-mode/builds/download-cpptcl.sh
+++ b/developer-mode/builds/download-cpptcl.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/flightaware/cpptcl.git
+

--- a/developer-mode/builds/download-critcl.sh
+++ b/developer-mode/builds/download-critcl.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/andreas-kupries/critcl.git
+

--- a/developer-mode/builds/download-itcl.sh
+++ b/developer-mode/builds/download-itcl.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/tcltk/itcl.git
+

--- a/developer-mode/builds/download-scotty.sh
+++ b/developer-mode/builds/download-scotty.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/flightaware/scotty.git
+

--- a/developer-mode/builds/download-sqlite3.sh
+++ b/developer-mode/builds/download-sqlite3.sh
@@ -1,0 +1,2 @@
+mkdir sqlite && cd sqlite && curl https://www.sqlite.org/2018/sqlite-autoconf-3250300.tar.gz | tar -xzf -
+

--- a/developer-mode/builds/download-tcl.sh
+++ b/developer-mode/builds/download-tcl.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/TCL-2020/tcl.git
+

--- a/developer-mode/builds/download-tclbsd.sh
+++ b/developer-mode/builds/download-tclbsd.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/flightaware/tclbsd.git
+

--- a/developer-mode/builds/download-tcllauncher.sh
+++ b/developer-mode/builds/download-tcllauncher.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/flightaware/tcllauncher.git
+

--- a/developer-mode/builds/download-tcllib.sh
+++ b/developer-mode/builds/download-tcllib.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/tcltk/tcllib.git
+

--- a/developer-mode/builds/download-tclreadline.sh
+++ b/developer-mode/builds/download-tclreadline.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/flightaware/tclreadline.git
+

--- a/developer-mode/builds/download-tcltls.sh
+++ b/developer-mode/builds/download-tcltls.sh
@@ -1,0 +1,2 @@
+mkdir -p tcltls && cd tcltls && curl 'https://core.tcl.tk/tcltls/uv/tcltls-1.7.16.tar.gz' | tar -xvzf -
+

--- a/developer-mode/builds/download-tclx.sh
+++ b/developer-mode/builds/download-tclx.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/flightaware/tclx.git
+

--- a/developer-mode/builds/download-tdom.sh
+++ b/developer-mode/builds/download-tdom.sh
@@ -1,0 +1,2 @@
+mkdir tdom && cd tdom && curl 'http://tdom.org/downloads/tdom-0.9.0-src.tgz' | tar -xvzf -
+

--- a/developer-mode/builds/download-yajl-tcl.sh
+++ b/developer-mode/builds/download-yajl-tcl.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/flightaware/yajl-tcl.git
+

--- a/developer-mode/setup-docker-env.sh
+++ b/developer-mode/setup-docker-env.sh
@@ -1,6 +1,8 @@
 apt-get update -qq
 
-apt-get install -y git gcc-7 g++-7 make curl automake autoconf minizip vim libreadline-dev libtool
+apt-get install -y git gcc-7 g++-7 make curl automake autoconf \
+    minizip vim libreadline-dev libtool cmake libyajl-dev \
+    libssl-dev openssl
 
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7
 update-alternatives --set cc /usr/bin/gcc-7


### PR DESCRIPTION
All of the download actions are now in /builds/download-<pkg>.sh.
You can download outside of the docker container into a
directory and mount that as /work in Docker.

To see all the downloads ```cat /builds/downloads-*.sh```.
To download all of the packages outside of the docker container.

mkdir work && cd && work
cat /builds/download-*.sh | sh